### PR TITLE
Consider to remove SSL or make it configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "jquery": "^3.4.0",
     "jquery-csv": "^0.8.12",
     "popper.js": "^1.14.7",
-    "ssl-express-www": "^3.0.3",
     "strftime": "^0.10.0",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1"

--- a/server.js
+++ b/server.js
@@ -2,11 +2,9 @@ const express = require('express');
 const path = require('path');
 const serveStatic = require('serve-static');
 const history = require('connect-history-api-fallback');
-const secure = require('ssl-express-www');
 
 let app = express();
 
-app.use(secure);
 app.use(history());
 app.use(serveStatic(__dirname + "/dist"));
 


### PR DESCRIPTION
I don't think that encryption is in the scope of this Node service and right now it prevents users from connecting to the service.

I can only imagine the following deployments:
* small company, everyone trusts each other: no encryption needed
* bigger company, encryption needed: They will probably have a more centralized approach like an Nginx in front of a lot of internal services where SSL terminates
* Public EC2 or other cloud vendor instance, encryption needed: There is probably a way to configure it on their end