### PR TITLE
Enable processing of sub-second data

### DIFF
--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -86,9 +86,9 @@ export default {
             var isMatch = /([+-](\d{2})\:?(\d{2}))$/.exec(fileText[i][1]);
             if (isMatch != null && /^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
               var safariDate = fileText[i][1].replace(isMatch[0], "");
-              date = strftime('%Y-%m-%d %H:%M:%S', new Date(safariDate)) + isMatch[0];
+              date = strftime('%Y-%m-%dT%H:%M:%S.%L', new Date(safariDate)) + isMatch[0];
             } else {
-              date = strftime('%Y-%m-%d %H:%M:%S%z', new Date(fileText[i][1]));
+              date = strftime('%Y-%m-%dT%H:%M:%S.%L%z', new Date(fileText[i][1]));
             }  
             timestamps.push(date.toString());
             values.push(fileText[i][2]);

--- a/src/components/Labeler.vue
+++ b/src/components/Labeler.vue
@@ -249,7 +249,7 @@ function labeller () {
   var quadtree;
   var context_data;
   var brushSelector = 'Invert';
-  var parseDate = d3.timeParse("%Y-%m-%d %H:%M:%S%Z");
+  var parseDate = d3.timeParse("%Y-%m-%dT%H:%M:%S.%L%Z");
 
   window.addEventListener("keydown", function(e) {
       // space and arrow keys
@@ -675,13 +675,21 @@ function labeller () {
           pad = function(num) {
               var norm = Math.floor(Math.abs(num));
               return (norm < 10 ? '0' : '') + norm;
-          };
+          },
+	  padms = function(ms) {
+	    ms = ms.toString()
+	    while (ms.length < 3) {
+	      ms = "0" + ms
+	    }
+	    return ms
+	  };
       return date.getFullYear() +
           '-' + pad(date.getMonth() + 1) +
           '-' + pad(date.getDate()) +
           'T' + pad(date.getHours()) +
           ':' + pad(date.getMinutes()) +
           ':' + pad(date.getSeconds()) +
+	  '.' + padms(date.getMilliseconds()) +
           dif + pad(tzo / 60) + pad(tzo % 60);
   }
 


### PR DESCRIPTION
- accepts date/timestamps with _exactly_ three decimal digits in the
seconds place (I suggest a comment somewhere in the help about that -- ISO8601 leaves the decimal digits of milliseconds up to implementation; three seems default for Javascript, but Python e.g. uses six).

- this **doesn't** change the strange behaviour of rewriting dates to local time on export

- this **does resolve** issue #69 