### PR TITLE
fix: replace filter by a for loop in getMinMax to prevent the call stack to fill up.

### DIFF
--- a/src/assets/js/LabelerD3.js
+++ b/src/assets/js/LabelerD3.js
@@ -761,8 +761,20 @@ export function drawLabeler(plottingApp) {
 
   /* return the bounds of the given y axis */
   function getMinMax(axis) {
-    var y_vals = plottingApp.allData.filter(d => d.series == axis).map(d => d.val),
-    minMax = [Math.min.apply(Math, y_vals), Math.max.apply(Math, y_vals)];
+    var y_vals = plottingApp.allData;
+    var row = y_vals[0];
+    var minMax = [ row.val, row.val, ];
+    for (var i=1; i < y_vals.length; i++) {
+        row = y_vals[i];
+        if (row.series == axis) {
+            if (row.val < minMax[0]) {
+                minMax[0] = row.val;
+            }
+            if (row.val > minMax[1]) {
+                minMax[1] = row.val;
+            }
+        }
+    }
     return padExtent(minMax, 0.1);
   }
 


### PR DESCRIPTION
When uploading a time series that is too large, the upload fails with error `RangeError: Maximum call stack size exceeded`.
This is due to the use of `filter(...).map(...)` in [the getMinMax function](https://github.com/Geocene/trainset/blob/master/src/assets/js/LabelerD3.js#L763), as it fills the call stack with small function calls.
Possibly related to https://github.com/Geocene/trainset/issues/109